### PR TITLE
fixed application edit

### DIFF
--- a/app/api/applicationGroup/find/companies/route.js
+++ b/app/api/applicationGroup/find/companies/route.js
@@ -10,7 +10,6 @@ export async function GET(request) {
   if (!sub || typeof provider !== "string") return unauthenticatedResponse;
 
   const user = await getRequestUser({ sub, provider });
-  console.log(user);
   const userId = user.id;
 
   if (!userId || isNaN(parseInt(userId))) {
@@ -22,7 +21,7 @@ export async function GET(request) {
 
   const companies = await prisma.company.findMany({
     where: {
-      userId: parseInt(userId),
+      userId,
     },
     select: {
       name: true,

--- a/services/jobService.ts
+++ b/services/jobService.ts
@@ -203,6 +203,10 @@ export const updateJob = async ({
       id: existingJob.id,
     },
     data: {
+      title: job.title,
+      responsibilities: job.responsibilities,
+      companyId: job.companyId,
+      workMode: job.workMode,
       description: job.description,
       compensation: {
         update: {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -145,15 +145,15 @@ export interface JobInterface {
 }
 
 export interface CompensationInterface {
-  id: number;
+  id?: number;
   payAmount: number;
   payFrequency: PayFrequencyEnum;
   currency: string;
   salaryRangeMin?: number | undefined;
   salaryRangeMax?: number | undefined;
-  hoursWeek: number;
-  negotiable: boolean;
-  jobId: number;
+  hoursWeek?: number;
+  negotiable?: boolean;
+  jobId?: number;
 }
 
 export interface ApplicationBoardInterface {


### PR DESCRIPTION
## Context
When you click an application card on the board, a form comes up to modify the details. When you make edits, the "close" button becomes a "Save Changes" button. However, changes are just rejected due to a server error.

The server error was due to a mismatch in the interface of the job with the actual arguments being passed in.
## What does this PR do?
- updated arguments going into Job service to match the interface of Job
- logged stack trace to the server when there's an error
- prisma does not support nested transactions, so we moved the logic of updateCompany out of a transaction
- accessed the user from the request
## Link to task
https://scarbel.atlassian.net/browse/JAT-1
## Demo


https://github.com/rscarbel/job-application-tracking/assets/116959418/906bb65b-6224-4e67-8e35-ed5fd5cbf830

