### PR TITLE
report error works correctly

### DIFF
--- a/app/api/ExtendedNextApiRequest.ts
+++ b/app/api/ExtendedNextApiRequest.ts
@@ -1,0 +1,5 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export interface ExtendedNextApiRequest extends NextApiRequest {
+  json: () => Promise<any>;
+}

--- a/app/api/applicationGroup/createCard/route.ts
+++ b/app/api/applicationGroup/createCard/route.ts
@@ -6,9 +6,10 @@ import { reportError } from "@/app/api/reportError/reportError";
 import { getRequestUser } from "@/services/userService";
 import { CreateCardRequest } from "./interface";
 import serverErrorResponse from "@/app/api/serverErrorResponse";
+import { ExtendedNextApiRequest } from "@/app/api/ExtendedNextApiRequest";
 
-export async function POST(request) {
-  const requestData = await request.json();
+export async function POST(request: ExtendedNextApiRequest) {
+  const requestData = await request.body.json();
   const createCardRequest: CreateCardRequest = requestData;
   const {
     applicationDate,
@@ -106,7 +107,7 @@ export async function POST(request) {
     });
     return new Response(JSON.stringify({ error: null }), { status: 200 });
   } catch (error) {
-    reportError(error);
+    reportError(error, user);
     return serverErrorResponse(error.message, 500);
   }
 }

--- a/app/api/applicationGroup/createGroup/route.ts
+++ b/app/api/applicationGroup/createGroup/route.ts
@@ -2,8 +2,9 @@ import { reportError } from "@/app/api/reportError/reportError";
 import { createApplicationBoard } from "@/services/applicationGroupService";
 import { getRequestUser } from "@/services/userService";
 import serverErrorResponse from "../../serverErrorResponse";
+import { ExtendedNextApiRequest } from "@/app/api/ExtendedNextApiRequest";
 
-export async function POST(request) {
+export async function POST(request: ExtendedNextApiRequest) {
   const { name } = await request.json();
   if (typeof name !== "string") {
     return serverErrorResponse(
@@ -21,7 +22,7 @@ export async function POST(request) {
       userId: user.id,
     });
   } catch (error) {
-    reportError(error);
+    reportError(error, user);
 
     return serverErrorResponse();
   }

--- a/app/api/applicationGroup/find/card/route.ts
+++ b/app/api/applicationGroup/find/card/route.ts
@@ -1,8 +1,9 @@
 import { getFormattedCardData } from "@/services/applicationService";
 import { getRequestUser } from "@/services/userService";
 import serverErrorResponse from "@/app/api/serverErrorResponse";
+import { ExtendedNextApiRequest } from "@/app/api/ExtendedNextApiRequest";
 
-export async function GET(request) {
+export async function GET(request: ExtendedNextApiRequest) {
   const { searchParams } = new URL(request.url);
   const applicationId = parseInt(searchParams.get("applicationId"));
 

--- a/app/api/applicationGroup/updateCard/route.ts
+++ b/app/api/applicationGroup/updateCard/route.ts
@@ -10,8 +10,9 @@ import { calculateBoardStructure } from "../calculateBoardStructure";
 import { reportError } from "@/app/api/reportError/reportError";
 import { getRequestUser } from "@/services/userService";
 import serverErrorResponse from "../../serverErrorResponse";
+import { ExtendedNextApiRequest } from "../../ExtendedNextApiRequest";
 
-export async function POST(request) {
+export async function POST(request: ExtendedNextApiRequest) {
   const {
     applicationId,
     groupId,
@@ -33,6 +34,8 @@ export async function POST(request) {
     notes,
     status,
   } = await request.json();
+
+  console.log(company);
 
   const necessaryData = {
     "Application Card": applicationId,
@@ -131,7 +134,7 @@ export async function POST(request) {
     });
   } catch (error) {
     console.error(error.stack);
-    reportError(error);
+    reportError(error, user);
     return serverErrorResponse(error.message, 500);
   }
 }

--- a/app/api/applicationGroup/updateStatus/route.ts
+++ b/app/api/applicationGroup/updateStatus/route.ts
@@ -2,9 +2,16 @@ import prisma from "@/services/globalPrismaClient";
 import { getRequestUser } from "@/services/userService";
 import { reportError } from "@/app/api/reportError/reportError";
 import serverErrorResponse from "../../serverErrorResponse";
+import { ExtendedNextApiRequest } from "@/app/api/ExtendedNextApiRequest";
 
-export async function POST(request) {
-  const { id, status, newPositionIndex } = await request.json();
+interface RequestBody {
+  id: string;
+  status: string;
+  newPositionIndex: number;
+}
+
+export async function POST(request: ExtendedNextApiRequest) {
+  const { id, status, newPositionIndex }: RequestBody = await request.json();
   const user = await getRequestUser(request);
   if (!user) return serverErrorResponse("The request user does not exist", 404);
 
@@ -106,7 +113,7 @@ export async function POST(request) {
       status: 200,
     });
   } catch (error) {
-    reportError(error);
+    reportError(error, user);
     return serverErrorResponse(error.message, 500);
   }
 }

--- a/app/api/reportError/ErrorReportInterface.ts
+++ b/app/api/reportError/ErrorReportInterface.ts
@@ -7,6 +7,5 @@ export interface UserReportInterface {
 
 export interface ReportErrorObjectInterface {
   message: string;
-  stack?: string;
-  user?: UserReportInterface;
+  stack: string;
 }

--- a/app/api/reportError/route.ts
+++ b/app/api/reportError/route.ts
@@ -1,11 +1,13 @@
 import { reportError } from "./reportError";
 import serverErrorResponse from "../serverErrorResponse";
+import { getRequestUser } from "@/services/userService";
+import { NextApiRequest } from "next";
 
-export async function POST(request: Request): Promise<Response> {
+export async function POST(request: NextApiRequest): Promise<Response> {
   try {
-    const { error } = await request.json();
-
-    reportError(error);
+    const { error } = await request.body.json();
+    const user = await getRequestUser(request);
+    reportError(error, user);
 
     return new Response(JSON.stringify({ success: true }), {
       status: 200,

--- a/app/form/ReadEditCompaniesField.jsx
+++ b/app/form/ReadEditCompaniesField.jsx
@@ -47,7 +47,7 @@ const ReadEditCompaniesField = ({
     if (selected) {
       setCompany(selected);
     } else {
-      setCompany({ name: e.value, companyId: undefined });
+      setCompany({ name: e.value, companyId: selectedCompany.companyId });
     }
   };
 

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -7,8 +7,19 @@ export const getRequestUser = async (
   request: NextApiRequest
 ): Promise<User | null> => {
   const token = await getToken({ req: request });
+
   const { sub, provider } = token || { sub: null, provider: null };
   if (!sub || typeof provider !== "string") return null;
+
+  if (provider === "credentials") {
+    const user = await prisma.user.findUnique({
+      where: {
+        email: token.email,
+      },
+    });
+
+    return user;
+  }
 
   const authRecord = await prisma.oAuth.findUnique({
     where: {

--- a/utils/global.ts
+++ b/utils/global.ts
@@ -1,6 +1,5 @@
 import countrySymbols from "@/lib/data/countrySymbols";
 import currenciesList from "@/lib/data/currenciesList";
-import { UserReportInterface } from "@/app/api/reportError/ErrorReportInterface";
 
 export const STYLE_CLASSES = {
   FORM_BASIC_INPUT:
@@ -52,13 +51,11 @@ interface ErrorInterface {
 }
 
 export const reportErrorToServer = async (
-  error: ErrorInterface,
-  userInfo: UserReportInterface = null
+  error: ErrorInterface
 ): Promise<void> => {
   const errorInfo = {
     message: error.message,
     stack: error.stack,
-    user: userInfo,
   };
 
   await fetch("/api/reportError", {


### PR DESCRIPTION
Across the app I am now collecting the information I need and passing the user to the reporting software, when possible.

This also fixes some types in network requests.

I had to extend the `NextApiRequest` interface, because the initial request is actually be received as a standard `Request` type which includes a `.json()` async method to parse it. Unfortunately, while I'm sure next has great middleware, it is really a problem because the request is only becoming of type NextApiRequest after I've already received the request and I pass it along to a different function.