### PR TITLE
corrected company preferences reference

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -274,7 +274,7 @@ async function main() {
             ...companyDetails,
           },
         },
-        companyPreference: {
+        preferences: {
           create: {
             desireability: getRandomDesireability(),
             notes: faker.lorem.sentences(3),


### PR DESCRIPTION
Recently, the preferences were broken off from the company details model. The column was named incorrectly in the seed file