### PR TITLE
Bugfix - Company List 

### DIFF
--- a/app/network.ts
+++ b/app/network.ts
@@ -74,7 +74,8 @@ export const findCompanies = async (): Promise<CompanyInterface[]> => {
   try {
     const response = await fetch("/api/applicationGroup/find/companies");
     const text = await response.text();
-    return JSON.parse(text);
+    const parsedText = JSON.parse(text);
+    return parsedText.body;
   } catch (error: any) {
     await reportErrorToServer(error);
     return [];


### PR DESCRIPTION
Create card was throwing an error when trying to call company names. The drop down with company names would not load. 
The list of companies was expected to be an array, but the network response was not being fully parsed so it was an object instead. 

![image](https://github.com/rscarbel/job-application-tracking/assets/116959418/52a6c0d1-1929-4f50-a49d-1a95cfbb0995)
